### PR TITLE
Add gains for PID control of wheels

### DIFF
--- a/doogie_control/config/wheel_control.yaml
+++ b/doogie_control/config/wheel_control.yaml
@@ -45,3 +45,22 @@ move_base_controller:
       max_acceleration       : 1.5  # rad/s^2
       has_jerk_limits        : true
       max_jerk               : 2.5  # rad/s^3
+
+# PID settings for class control_toobox::PID used in control loop of the Doogie Mouse wheels 
+left_wheel_pid:
+  p: 1.18
+  i: 14.88
+  d: 0.0
+  i_clamp_min: -100.0
+  i_clamp_max: 100.0
+  antiwindup: true
+  publish_state: true
+
+right_wheel_pid:
+  p: 1.18
+  i: 14.88
+  d: 0.0
+  i_clamp_min: -100.0
+  i_clamp_max: 100.0
+  antiwindup: true
+  publish_state: true

--- a/doogie_control/launch/robot_control.launch
+++ b/doogie_control/launch/robot_control.launch
@@ -4,7 +4,7 @@
     <rosparam file="$(find doogie_control)/config/wheel_control.yaml" command="load"/>
 
     <node pkg="controller_manager" type="spawner" name="spawns_control" 
-        output="screen" respawn="false" args="--namespace=/$(arg ns) --timeout 5
+        output="screen" respawn="false" args="--namespace=/$(arg ns) --timeout 20
                                                 joint_publisher move_base_controller" />
 
 </launch>


### PR DESCRIPTION
These parameters are used for internals Nodehandle used by control_toolbox::PID class